### PR TITLE
Rename variables and fix nonlinear palette behaviour

### DIFF
--- a/DarkCloudModelTools/filetypes/IMG/IMGBinary.py
+++ b/DarkCloudModelTools/filetypes/IMG/IMGBinary.py
@@ -83,19 +83,21 @@ class TIM2(Serializable):
             super().__init__(context)
             self.filetype  = b'TIM2'
             self.version   = None
-            self.format    = None
+            self.alignment = None
             self.tex_count = None
         
         def __repr__(self):
-            return f"[TIM2::Header] {self.filetype} {self.version} {self.format} {self.tex_count}"
+            return f"[TIM2::Header] {self.filetype} {self.version} {self.alignment} {self.tex_count}"
     
         def read_write(self, rw):
             self.filetype  = rw.rw_bytestring(self.filetype, 0x04)
             assert self.filetype == b'TIM2', self.filetype
             self.version   = rw.rw_uint8(self.version)
-            self.format    = rw.rw_uint8(self.format)
+            self.alignment = rw.rw_uint8(self.alignment) # 0 or 1
             self.tex_count = rw.rw_uint16(self.tex_count)
             rw.align(rw.tell(), 0x10)
+            if self.alignment == 1:
+                rw.align(rw.tell(), rw.tell() + 0x70)
         
     class TIM2Image(Serializable):
         def __init__(self, context=None):

--- a/DarkCloudModelTools/filetypes/IMG/ImageInterface.py
+++ b/DarkCloudModelTools/filetypes/IMG/ImageInterface.py
@@ -28,8 +28,8 @@ class ImageInterface:
     def __parse_clut(tm2):
         # Set up convenience variables
         is_linear = (tm2.header.clut_colour_type & 0x80) != 0
-        clut_colour_count = tm2.header.clut_colour_count
         clut_colour_type = tm2.header.clut_colour_type & 0x7F
+        clut_colour_count = tm2.header.clut_colour_count
         image_colour_type = tm2.header.image_colour_type
         
         # Determine clut colour size
@@ -50,9 +50,9 @@ class ImageInterface:
                 palette = struct.unpack('H'*palette_colour_count, tm2.clut)
                 for palette_idx, palette_value in enumerate(palette):
                     colour = [None, None, None, None]
-                    colour[0] = ((palette_value >> 11) & 0x05) / 32
-                    colour[1] = ((palette_value >>  6) & 0x05) / 32
-                    colour[2] = ((palette_value >>  1) & 0x05) / 32
+                    colour[0] = ((palette_value >> 11) & 0x05) / 31
+                    colour[1] = ((palette_value >>  6) & 0x05) / 31
+                    colour[2] = ((palette_value >>  1) & 0x05) / 31
                     colour[3] = ((palette_value >>  0) & 0x01) /  1
                     palette[palette_idx] = colour
             elif clut_colour_size == 3: # 24BIT_RGB Format
@@ -77,11 +77,11 @@ class ImageInterface:
             else:
                 raise ValueError(f"Invalid CLUT colour count: {clut_colour_count}")
                  
-            if (not is_linear) and (image_colour_type == 4): # 4 BPP
-                parts = palette_size / 32;
-                stripes=2;
-                colours = 8;
-                blocks = 2;
+            if (not is_linear):
+                parts   = palette_size // (32*4)
+                stripes = 2
+                colours = 8
+                blocks  = 2
     
                 new_idx = 0
                 new_palette = [None]*len(palette)
@@ -93,6 +93,7 @@ class ImageInterface:
                                 old_idx += block * colours
                                 old_idx += stripe * stripes * colours
                                 old_idx += colour
+                                print(len(new_palette), old_idx, new_idx, parts*blocks*stripes*colours)
                                 new_palette[new_idx] = palette[old_idx]
                                 new_idx += 1
                 palette = new_palette


### PR DESCRIPTION
- Fix non-linear palettes
- Fix colour decodes for ABGR5551 storage
- Rename `TIM2::Header::format -> TIM2::Header::alignment` to make more semantic sense

Support for more TIM2 types can be implemented after issues preventing the full parsing of the set of *.chr files has been fixed.